### PR TITLE
modalLoadingが消えるように修正しました

### DIFF
--- a/src/js/main.js
+++ b/src/js/main.js
@@ -101,6 +101,7 @@
   // modalSuccessが表示されたタイミングでmodalLoadingを非表示にする
   $("#modalSuccess").on('shown.bs.modal', function () {
     $('#modalLoading').modal('hide')
+    $('#modalPost').modal('hide')
   });
 
   // 投稿処理


### PR DESCRIPTION
# 対応内容

既存のコードでは、modalLoadingが非表示にならなかった。
原因としては、 `$('#modalPost').modal('hide');`が呼ばれるタイミングでは、modalLoadingの表示が完了していなかったので、`$('#modalPost').modal('hide');`が効かなかった模様。
そこでmodalSuccessの表示が完了したタイミングで、modalLoadingを消えるようにした。